### PR TITLE
Fix two bugs in the typeDef parser

### DIFF
--- a/src/resolveTypeDefs.js
+++ b/src/resolveTypeDefs.js
@@ -10,7 +10,7 @@ export default function () {
 
   /* Search for all types */
   allTypesDefs.forEach(def => {
-    const regex = /([A-z ]+){\n?(([^{}])+)}/g
+    const regex = /([A-z0-9 ,]+){\n?(([^{}])+)}/g
     let m
 
     while ((m = regex.exec(def)) !== null) {


### PR DESCRIPTION
 - Don't mess up the type definitions when there is a number in a type name.
 - Don't mess up the type definitions when a type inmplements multiple interfaces,
   and therefore it uses a comma.

Fixes #4.
Fixes #5.